### PR TITLE
Add CSS class to draggable piece

### DIFF
--- a/src/cm-chessboard/ChessboardMoveInput.js
+++ b/src/cm-chessboard/ChessboardMoveInput.js
@@ -175,6 +175,7 @@ export class ChessboardMoveInput {
             throw Error("draggablePiece exists")
         }
         this.draggablePiece = Svg.createSvg(document.body)
+        this.draggablePiece.classList.add("cm-chessboard-draggable-piece")
         this.draggablePiece.setAttribute("width", this.view.squareWidth)
         this.draggablePiece.setAttribute("height", this.view.squareHeight)
         this.draggablePiece.setAttribute("style", "pointer-events: none")


### PR DESCRIPTION
Added a CSS class to the created draggable piece SVG. This way, it can be specifically selected via CSS when it is dragged and there are other SVG elements inside the document body.

I created this PR for the following reason: I'm using the chessboard inside a positioned container with a z-index. The draggable piece SVG is created as a direct child of the body and has no z-index per default, which is fine by me, but that makes it disappear behind my parent container element. Since there can be other SVG elements as well on the document body, I needed a class to style the draggable piece to my needs.