### PR TITLE
Replace random function with randomIndex

### DIFF
--- a/examples/validate-moves.html
+++ b/examples/validate-moves.html
@@ -52,10 +52,6 @@ board.enableMoveInput(inputHandler, COLOR.white)
 <script type="module">
     import {INPUT_EVENT_TYPE, MOVE_INPUT_MODE, COLOR, Chessboard} from "../src/cm-chessboard/Chessboard.js"
 
-    function random(min, max) {
-        return Math.floor(Math.random() * (max - min + 1)) + min
-    }
-
     const chess = new Chess()
 
     function inputHandler(event) {
@@ -68,7 +64,8 @@ board.enableMoveInput(inputHandler, COLOR.white)
                 event.chessboard.setPosition(chess.fen())
                 const possibleMoves = chess.moves({verbose: true})
                 if (possibleMoves.length > 0) {
-                    const randomMove = possibleMoves[random(0, possibleMoves.length - 1)]
+                    const randomIndex = Math.floor(Math.random() * possibleMoves.length);
+                    const randomMove = possibleMoves[randomIndex];
                     chess.move({from: randomMove.from, to: randomMove.to})
                     event.chessboard.enableMoveInput(inputHandler, COLOR.white)
                     event.chessboard.setPosition(chess.fen())


### PR DESCRIPTION
Hi,
While experimenting with cm-chessboard, I found it useful to replace a separate random function in [this example page](https://github.com/shaack/cm-chessboard/blob/master/examples/validate-moves.html) with a random index like this:
``` JavaScript
const randomIndex = Math.floor(Math.random() * possibleMoves.length);
const randomMove = possibleMoves[randomIndex];
```
Since it's not explicitly mentioned when readers view [the documentation page](https://shaack.com/projekte/cm-chessboard/examples/validate-moves.html), it could potentially add a bit of confusion to first time users. Besides, the replacement makes inputHandler a more modular block of code (plug and play).
