### PR TITLE
Remove Asynchronous Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Returns the board orientation.
 
 ### destroy()
 
-Removes the board from the DOM. Returns a **Promise** which will be resolved, after destruction.
+Removes the board from the DOM.
 
 [Example for **destroy**](https://shaack.com/projekte/cm-chessboard/examples/destroy-many-boards.html)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cm-chessboard
 
-A JavaScript chessboard which is lightweight, ES6 module based, responsive, SVG rendered and **without dependencies**. 
+A JavaScript chessboard which is lightweight, ES6 module based, responsive, SVG rendered and **without dependencies**.
 
 It works on desktop (current versions of Chrome, Firefox, Safari, Edge), and mobile (Android and iOS).
 
@@ -101,8 +101,6 @@ props = {
 Sets a piece on a square. Example: `board.setPiece("e4", PIECE.blackKnight)` or
 `board.setPiece("e4", "bn")`.
 
-Returns a **Promise** which will be resolved, after the piece is set.
-
 ### getPiece(square)
 
 Returns the piece on a square or `undefined` if the square is empty.
@@ -124,9 +122,9 @@ Returns the board position as `fen`.
 
 Adds a marker on a square.
 
-Default types are: `MARKER_TYPE.frame`, `MARKER_TYPE.square`, `MARKER_TYPE.dot`, `MARKER_TYPE.circle` exportet by `Chessboard.js`. 
+Default types are: `MARKER_TYPE.frame`, `MARKER_TYPE.square`, `MARKER_TYPE.dot`, `MARKER_TYPE.circle` exportet by `Chessboard.js`.
 
-#### You can create your own marker types: 
+#### You can create your own marker types:
 
 Just create an object like `const myMarker = {class: "markerCssClass", slice: "markerSliceId"}`, where `class` is the css class of the marker for styling
 and `slice` is the `id` in `sprite.svg`. See also [Create your own custom markers](#create-your-own-custom-markers)
@@ -211,7 +209,7 @@ Disables moves via user input.
 
 ### enableSquareSelect(eventHandler)
 
-Enables primary and secondary pointer events on squares. 
+Enables primary and secondary pointer events on squares.
 On desktop devices this means left and right click on squares.
 
 ```javascript
@@ -247,8 +245,8 @@ markers are defined in the sprite.
 
 ## Create your own custom markers
 
-The ability to add custom markers is build in. You can use the existing 
-marker shapes in the SVG sprite and create your own markers with just css or create 
+The ability to add custom markers is build in. You can use the existing
+marker shapes in the SVG sprite and create your own markers with just css or create
 your own custom SVG shapes. With a program like InkScape or Sketch this should be relatively easy.
 
 Example: The markerCircle is defined in the SVG like this.
@@ -319,5 +317,5 @@ https://github.com/shaack/cm-chessboard/issues/20
 
 You may also be interested in [cm-chess](https://github.com/shaack/cm-chess), it is like
 [chess.js](https://github.com/jhlywa/chess.js), but in ES6 and can handle games and PGNs with variants, NAGs and
-comments. 
+comments.
 

--- a/examples/pieces-animation.html
+++ b/examples/pieces-animation.html
@@ -30,9 +30,6 @@
             sprite: {url: "../assets/images/chessboard-sprite-staunty.svg"},
             animationDuration: 500
         })
-    board.initialization.then(() => {
-        console.log("initialization resolved")
-    })
     let i = 0
     window.setPosition = (position) => {
         i++

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -96,11 +96,8 @@ export class Chessboard {
     // API //
 
     setPiece(square, piece) {
-        return new Promise((resolve) => {
-            this.state.setPiece(this.state.squareToIndex(square), piece)
-            this.view.drawPieces(this.state.squares)
-            resolve()
-        })
+        this.state.setPiece(this.state.squareToIndex(square), piece)
+        this.view.drawPieces(this.state.squares)
     }
 
     getPiece(square) {

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -89,9 +89,8 @@ export class Chessboard {
                 } else {
                     this.state.setPosition(this.props.position)
                 }
-                view.redraw().then(() => {
-                    resolve()
-                })
+                view.redraw()
+                resolve()
             })
         })
     }

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -184,17 +184,14 @@ export class Chessboard {
     }
 
     destroy() {
-        return new Promise((resolve) => {
-            this.view.destroy()
-            this.view = undefined
-            this.state = undefined
-            if (this.squareSelectListener) {
-                this.element.removeEventListener("contextmenu", this.squareSelectListener)
-                this.element.removeEventListener("mouseup", this.squareSelectListener)
-                this.element.removeEventListener("touchend", this.squareSelectListener)
-            }
-            resolve()
-        })
+        this.view.destroy()
+        this.view = undefined
+        this.state = undefined
+        if (this.squareSelectListener) {
+            this.element.removeEventListener("contextmenu", this.squareSelectListener)
+            this.element.removeEventListener("mouseup", this.squareSelectListener)
+            this.element.removeEventListener("touchend", this.squareSelectListener)
+        }
     }
 
     enableMoveInput(eventHandler, color = undefined) {

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -156,7 +156,7 @@ export class Chessboard {
             console.error("Error addMarker(), type is " + type)
         }
         this.state.addMarker(this.state.squareToIndex(square), type)
-        this.view.drawMarkersDebounced()
+        this.view.drawMarkers()
     }
 
     getMarkers(square = undefined, type = undefined) {
@@ -175,7 +175,7 @@ export class Chessboard {
     removeMarkers(square = undefined, type = undefined) {
         const index = square ? this.state.squareToIndex(square) : undefined
         this.state.removeMarkers(index, type)
-        this.view.drawMarkersDebounced()
+        this.view.drawMarkers()
     }
 
     setOrientation(color) {

--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -102,7 +102,8 @@ export class Chessboard {
         return new Promise((resolve) => {
             this.initialization.then(() => {
                 this.state.setPiece(this.state.squareToIndex(square), piece)
-                this.view.drawPiecesDebounced(this.state.squares).then(resolve)
+                this.view.drawPieces(this.state.squares)
+                resolve()
             })
         })
     }
@@ -131,7 +132,8 @@ export class Chessboard {
                             resolve()
                         })
                     } else {
-                        this.view.drawPiecesDebounced(this.state.squares).then(resolve)
+                        this.view.drawPieces(this.state.squares)
+                        resolve()
                     }
                 } else {
                     if (this.previousPromise) {

--- a/src/cm-chessboard/ChessboardMoveInput.js
+++ b/src/cm-chessboard/ChessboardMoveInput.js
@@ -147,14 +147,12 @@ export class ChessboardMoveInput {
                             this.setMoveInputState(STATE.reset)
                         })
                     } else {
-                        this.view.drawPieces(this.chessboard.state.squares).then(() => {
-                            this.setMoveInputState(STATE.reset)
-                        })
+                        this.view.drawPieces(this.chessboard.state.squares)
+                        this.setMoveInputState(STATE.reset)
                     }
                 } else {
-                    this.view.drawPiecesDebounced().then(() => {
-                        this.setMoveInputState(STATE.reset)
-                    })
+                    this.view.drawPieces()
+                    this.setMoveInputState(STATE.reset)
                 }
                 break
 
@@ -356,15 +354,13 @@ export class ChessboardMoveInput {
                     this.moveCanceledCallback(MOVE_CANCELED_REASON.secondClick, index)
                 }
             } else {
-                this.view.drawPiecesDebounced().then(() => {
-                    this.setMoveInputState(STATE.reset)
-                    this.moveCanceledCallback(MOVE_CANCELED_REASON.movedOutOfBoard, undefined)
-                })
+                this.view.drawPieces()
+                this.setMoveInputState(STATE.reset)
+                this.moveCanceledCallback(MOVE_CANCELED_REASON.movedOutOfBoard, undefined)
             }
         } else {
-            this.view.drawPiecesDebounced().then(() => {
-                this.setMoveInputState(STATE.reset)
-            })
+            this.view.drawPieces()
+            this.setMoveInputState(STATE.reset)
         }
     }
 

--- a/src/cm-chessboard/ChessboardMoveInput.js
+++ b/src/cm-chessboard/ChessboardMoveInput.js
@@ -385,7 +385,7 @@ export class ChessboardMoveInput {
                 this.chessboard.state.addMarker(this.endIndex, this.chessboard.props.style.hoverMarker)
             }
         }
-        this.view.drawMarkersDebounced()
+        this.view.drawMarkers()
     }
 
     reset() {

--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -77,7 +77,6 @@ export class ChessboardView {
         window.clearTimeout(this.resizeDebounce)
         window.clearTimeout(this.redrawDebounce)
         window.clearTimeout(this.drawPiecesDebounce)
-        window.clearTimeout(this.drawMarkersDebounce)
         Svg.removeElement(this.svg)
         this.animationQueue = []
         if (this.currentAnimation) {
@@ -321,13 +320,6 @@ export class ChessboardView {
     }
 
     // Markers //
-
-    drawMarkersDebounced() {
-        window.clearTimeout(this.drawMarkersDebounce)
-        this.drawMarkersDebounce = setTimeout(() => {
-            this.drawMarkers()
-        }, 10)
-    }
 
     drawMarkers() {
         while (this.markersGroup.firstChild) {

--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -425,15 +425,13 @@ export class ChessboardView {
     // Helpers //
 
     setCursor() {
-        this.chessboard.initialization.then(() => {
-            if (this.chessboard.state) { // fix https://github.com/shaack/cm-chessboard/issues/47
-                if (this.chessboard.state.inputWhiteEnabled || this.chessboard.state.inputBlackEnabled || this.chessboard.state.squareSelectEnabled) {
-                    this.boardGroup.setAttribute("class", "board input-enabled")
-                } else {
-                    this.boardGroup.setAttribute("class", "board")
-                }
+        if (this.chessboard.state) { // fix https://github.com/shaack/cm-chessboard/issues/47
+            if (this.chessboard.state.inputWhiteEnabled || this.chessboard.state.inputBlackEnabled || this.chessboard.state.squareSelectEnabled) {
+                this.boardGroup.setAttribute("class", "board input-enabled")
+            } else {
+                this.boardGroup.setAttribute("class", "board")
             }
-        })
+        }
     }
 
     squareIndexToPoint(index) {

--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -75,7 +75,6 @@ export class ChessboardView {
         this.chessboard.element.removeEventListener("mousedown", this.pointerDownListener)
         this.chessboard.element.removeEventListener("touchstart", this.pointerDownListener)
         window.clearTimeout(this.resizeDebounce)
-        window.clearTimeout(this.redrawDebounce)
         Svg.removeElement(this.svg)
         this.animationQueue = []
         if (this.currentAnimation) {
@@ -152,17 +151,11 @@ export class ChessboardView {
     }
 
     redraw() {
-        return new Promise((resolve) => {
-            window.clearTimeout(this.redrawDebounce)
-            this.redrawDebounce = setTimeout(() => {
-                this.drawBoard()
-                this.drawCoordinates()
-                this.drawMarkers()
-                this.setCursor()
-            })
-            this.drawPieces(this.chessboard.state.squares)
-            resolve()
-        })
+        this.drawBoard()
+        this.drawCoordinates()
+        this.drawMarkers()
+        this.setCursor()
+        this.drawPieces(this.chessboard.state.squares)
     }
 
     // Board //

--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -76,7 +76,6 @@ export class ChessboardView {
         this.chessboard.element.removeEventListener("touchstart", this.pointerDownListener)
         window.clearTimeout(this.resizeDebounce)
         window.clearTimeout(this.redrawDebounce)
-        window.clearTimeout(this.drawPiecesDebounce)
         Svg.removeElement(this.svg)
         this.animationQueue = []
         if (this.currentAnimation) {
@@ -161,7 +160,8 @@ export class ChessboardView {
                 this.drawMarkers()
                 this.setCursor()
             })
-            this.drawPiecesDebounced(this.chessboard.state.squares).then(resolve)
+            this.drawPieces(this.chessboard.state.squares)
+            resolve()
         })
     }
 
@@ -256,29 +256,17 @@ export class ChessboardView {
 
     // Pieces //
 
-    drawPiecesDebounced(squares = this.chessboard.state.squares) {
-        return new Promise((resolve) => {
-            window.clearTimeout(this.drawPiecesDebounce)
-            this.drawPiecesDebounce = setTimeout(() => {
-                this.drawPieces(squares).then(resolve)
-            })
-        })
-    }
-
     drawPieces(squares = this.chessboard.state.squares) {
-        return new Promise((resolve) => { // TODO Promise is not necessary
-            const childNodes = Array.from(this.piecesGroup.childNodes)
-            for (let i = 0; i < 64; i++) {
-                const pieceName = squares[i]
-                if (pieceName) {
-                    this.drawPiece(i, pieceName)
-                }
+        const childNodes = Array.from(this.piecesGroup.childNodes)
+        for (let i = 0; i < 64; i++) {
+            const pieceName = squares[i]
+            if (pieceName) {
+                this.drawPiece(i, pieceName)
             }
-            for (const childNode of childNodes) {
-                this.piecesGroup.removeChild(childNode)
-            }
-            resolve()
-        })
+        }
+        for (const childNode of childNodes) {
+            this.piecesGroup.removeChild(childNode)
+        }
     }
 
     drawPiece(index, pieceName) {
@@ -362,13 +350,12 @@ export class ChessboardView {
             this.animationRunning = true
             this.currentAnimation = new ChessboardPiecesAnimation(this, nextAnimation.fromSquares, nextAnimation.toSquares, this.chessboard.props.animationDuration / (this.animationQueue.length + 1), () => {
                 if (!this.moveInput.draggablePiece) {
-                    this.drawPieces(nextAnimation.toSquares).then(() => {
-                        this.animationRunning = false
-                        this.nextPieceAnimationInQueue()
-                        if (nextAnimation.callback) {
-                            nextAnimation.callback()
-                        }
-                    })
+                    this.drawPieces(nextAnimation.toSquares)
+                    this.animationRunning = false
+                    this.nextPieceAnimationInQueue()
+                    if (nextAnimation.callback) {
+                        nextAnimation.callback()
+                    }
                 } else {
                     this.animationRunning = false
                     this.nextPieceAnimationInQueue()

--- a/test/TestBoard.js
+++ b/test/TestBoard.js
@@ -23,11 +23,9 @@ describe("TestBoard", () => {
             sprite: {url: "../assets/images/chessboard-sprite.svg"},
             position: "start"
         })
-        chessboard.initialization.then(() => {
-            assert.equals(chessboard.element.childNodes.length, 1)
-            chessboard.destroy().then(() => {
-                assert.equals(chessboard.state, undefined)
-            })
+        assert.equals(chessboard.element.childNodes.length, 1)
+        chessboard.destroy().then(() => {
+            assert.equals(chessboard.state, undefined)
         })
     })
 

--- a/test/TestBoard.js
+++ b/test/TestBoard.js
@@ -24,9 +24,8 @@ describe("TestBoard", () => {
             position: "start"
         })
         assert.equals(chessboard.element.childNodes.length, 1)
-        chessboard.destroy().then(() => {
-            assert.equals(chessboard.state, undefined)
-        })
+        chessboard.destroy()
+        assert.equals(chessboard.state, undefined)
     })
 
 })

--- a/test/TestPosition.js
+++ b/test/TestPosition.js
@@ -44,12 +44,10 @@ describe("TestPosition", () => {
             position: "empty",
             sprite: {url: "../assets/images/chessboard-sprite.svg"},
         })
-        chessboard.setPiece("a1", PIECE.bk).then(() => {
-            assert.equals(chessboard.getPiece("a1"), "bk")
-        })
-        chessboard.setPiece("e5", PIECE.wk).then(() => {
-            assert.equals(chessboard.getPiece("e5"), "wk")
-        })
+        chessboard.setPiece("a1", PIECE.bk)
+        assert.equals(chessboard.getPiece("a1"), "bk")
+        chessboard.setPiece("e5", PIECE.wk)
+        assert.equals(chessboard.getPiece("e5"), "wk")
         setTimeout(() => {
             chessboard.destroy()
         }, 100)

--- a/test/TestPosition.js
+++ b/test/TestPosition.js
@@ -33,12 +33,10 @@ describe("TestPosition", () => {
             sprite: {url: "../assets/images/chessboard-sprite.svg"},
             position: "start"
         })
-        chessboard.initialization.then(() => {
-            assert.equals(chessboard.getPiece("d1"), "wq")
-            assert.equals(chessboard.getPiece("d8"), "bq")
-            assert.equals(chessboard.getPiece("a2"), "wp")
-            chessboard.destroy()
-        })
+        assert.equals(chessboard.getPiece("d1"), "wq")
+        assert.equals(chessboard.getPiece("d8"), "bq")
+        assert.equals(chessboard.getPiece("a2"), "wp")
+        chessboard.destroy()
     })
 
     it("should set pieces on squares", () => {


### PR DESCRIPTION
This PR turned out to be a bit bigger than we discussed, but I think the additional work was helpful. 

Once I removed the debounce functions, it turns out that the `initialization` function was no longer needed because none of the code that was being initialized was asynchronous. I was also running into an issue with `setOrientation` once I made `ChessboardView#redraw` synchronous, and removing the `initialization` promise fixed it. This in turn meant that many of the functions that relied on `initialization` could also be made synchronous.

The end result of this is the only asynchronous function in `Chessboard.js` is `setPromise`. I had to refactor the promise logic a little in this function once `initialization` was removed, but I think the changes simplify things.

I'm especially pleased with how the `redraw` function turned out after the refactor:

``` js
redraw() {
    this.drawBoard()
    this.drawCoordinates()
    this.drawMarkers()
    this.setCursor()
    this.drawPieces(this.chessboard.state.squares)
}
```

Finally, I split the changes up into several commits. This should make reviewing the changes much easier, as you can see what happened at each one.

Please let me know if there's anything else you'd like to see here. Thanks!