### PR TITLE
Fix animation bug when moving a piece while an animation is running

### DIFF
--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -338,7 +338,6 @@ export class ChessboardView {
             this.animationRunning = true
             this.currentAnimation = new ChessboardPiecesAnimation(this, nextAnimation.fromSquares, nextAnimation.toSquares, this.chessboard.props.animationDuration / (this.animationQueue.length + 1), () => {
                 if (!this.moveInput.draggablePiece) {
-                    this.drawPieces(nextAnimation.toSquares)
                     this.animationRunning = false
                     this.nextPieceAnimationInQueue()
                     if (nextAnimation.callback) {

--- a/src/cm-chessboard/ChessboardView.js
+++ b/src/cm-chessboard/ChessboardView.js
@@ -336,6 +336,7 @@ export class ChessboardView {
         const nextAnimation = this.animationQueue.shift()
         if (nextAnimation !== undefined) {
             this.animationRunning = true
+            this.drawPieces(nextAnimation.fromSquares);
             this.currentAnimation = new ChessboardPiecesAnimation(this, nextAnimation.fromSquares, nextAnimation.toSquares, this.chessboard.props.animationDuration / (this.animationQueue.length + 1), () => {
                 if (!this.moveInput.draggablePiece) {
                     this.animationRunning = false


### PR DESCRIPTION
Hi,

There is a bug when doing a move while an animation is running.

Here is the current flow: `setPosition` is called -> the animation run -> `drawPiece` is called with the animation `toSquares`.

If during the animation the position change then the `drawPiece` will be called with an invalid state because the animation `toSquares` are not updated.

Removing the `drawPieces` at the end of the animation fix this bug and doesn't seem to affect the board behavior.

# Videos
Here is two videos, the one with the bug, the other with this PR fix.

https://user-images.githubusercontent.com/34145980/152351101-afe0fcb5-4463-49ba-8c16-4f9dc302f397.mp4

https://user-images.githubusercontent.com/34145980/152351180-cbc47c8e-6d47-4134-9c5a-5f34191c6abe.mp4


