### PR TITLE
Save references to instances of extensions

### DIFF
--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -97,7 +97,7 @@ export class Chessboard {
         this.view.redrawPieces()
         // instantiate extensions
         for (const extensionData of this.props.extensions) {
-            new extensionData.class(this, extensionData.props)
+            this.extensions.push(new extensionData.class(this, extensionData.props))
         }
     }
 


### PR DESCRIPTION
I wrote an extension that has some of its own state, which I wanted to access. However, it seems like Chessboard.js does not store references to the instances of extensions it creates with `new extensionData.class(this, extensionData.props)`, so it is not possible to access my extension's data. Or, at least I couldn't figure out a way without doing something a bit hacky, like passing a callback to the extension props that would allow it to send a reference to itself to the outside world.

I noticed that there was an unused `this.extensions = []` variable in the Chessboard constructor, so I feel like maybe that is the intended place to store those references. This pull request does so.

It also seems like there is a very small chance that extensions could get garbage collected on low-memory machines, if there is no saved reference to them. This pull request should also prevent that potential issue.