### PR TITLE
Handle calls to getPiece with no square, fixing uncaught TypeError with borderType "frame"

### DIFF
--- a/src/cm-chessboard/model/Position.js
+++ b/src/cm-chessboard/model/Position.js
@@ -112,7 +112,9 @@ export class Position {
     }
 
     getPiece(square) {
-        return this.squares[Position.squareToIndex(square)]
+        if (square) {
+            return this.squares[Position.squareToIndex(square)]
+        }
     }
 
     static squareToIndex(square) {


### PR DESCRIPTION
I like the look of `borderType: "frame"`, but I noticed some occasional uncaught type errors in my logger since switching to this style. Here is the stack trace:

    Position.js:119 Uncaught TypeError: Cannot read properties of null (reading 'substring')
    at Position.squareToIndex (Position.js:119:29)
    at Position.getPiece (Position.js:115:38)
    at Chessboard.getPiece (Chessboard.js:141:36)
    at VisualMoveInput.onPointerDown (VisualMoveInput.js:242:47)
    at ChessboardView.pointerDownHandler (ChessboardView.js:89:24)

After a while I realized this was happening on clicks to the frame. It seems that `VisualMoveInput.onPointerDown` checks `if (square) {`, handling the case where a click was not on a square. So, I assume this case was intended to be handled. However, `this.chessboard.getPiece(square)` happens before that and causes the error, since `getPiece` assumes a valid square is passed in.

This pull request checks in `Position.getPiece` whether a square has been passed in, and only tries to pass it on to `squareToIndex` if so. There are many ways this could be handled, at almost any of the steps of the stack trace, so maybe this isn't the preferred place. It just seemed like the best to me. Perhaps it could also handle invalid squares (e.g., 'a9', 'j2'), but I felt like an uncaught error is justified in such a scenario.

Below is the simple test case I used to verify it wasn't something else in my code:

```html
<!doctype html>
<html>
<head>
    <link rel="stylesheet" href="/js/lib/cm-chessboard/assets/styles/cm-chessboard.css">
    <title>frame test</title>
</head>
<body>
    Board:
    <div id="board"></div>

<script type="module">
import { Chessboard, MARKER_TYPE } from '/js/lib/cm-chessboard/src/cm-chessboard/Chessboard.js'

const board = new Chessboard(document.getElementById('board'), {
    position: 'start',
    sprite: {url: '/js/lib/cm-chessboard/assets/images/chessboard-sprite.svg'},
    style: {borderType: 'frame'}
})
</script>
</body>
</html>
```

Left-clicking on the coordinates or elsewhere on the frame causes the uncaught error.
(Paths may of course need adjusting if you wish to run it.)
