### PR TITLE
Add redrawBoard extension point to list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,8 @@ export const EXTENSION_POINT = {
     boardChanged: "boardChanged", // the board (orientation) was changed
     moveInputToggled: "moveInputToggled", // move input was enabled or disabled
     moveInput: "moveInput", // move started, canceled or validation // TODO validation in extensions is not awailable for now
-    destroy: "destroy" // called, before the board is destroyed
+    destroy: "destroy", // called, before the board is destroyed
+    redrawBoard: "redrawBoard" // called while redrawing the board
 }
 ```
 


### PR DESCRIPTION
I needed to re-add some mouse handlers for an extension after the board gets redrawn and couldn't figure out how from the README. The Arrows extension pointed me in the direction of the `redrawBoard` extension point which did exactly what I needed, so I thought it might be nice to have in the README for others' future reference too.