### PR TITLE
Fix some module errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "widget"
   ],
   "type": "module",
+  "module": "./src/cm-chessboard/Chessboard.js",
   "browser": "./src/cm-chessboard/Chessboard.js",
   "scripts": {
     "test": "tput setaf 4;echo 'Run test/index.html in your browser for unit testing.'; echo ''; exit 0"


### PR DESCRIPTION
Tried  sveltekit frontend, I got the following error: 
<img width="1222" alt="Снимок экрана 2022-11-10 в 20 36 02" src="https://user-images.githubusercontent.com/102977623/201166837-bcd1a520-9a1b-410a-8cc6-b3c82c68d92f.png">

So, fixing added "module" and path.