### PR TITLE
Re-export FEN at the top level

### DIFF
--- a/src/cm-chessboard/Chessboard.js
+++ b/src/cm-chessboard/Chessboard.js
@@ -39,6 +39,8 @@ export const PIECES_FILE_TYPE = {
     svgSprite: "svgSprite"
 }
 
+export {FEN}
+
 export class Chessboard {
 
     constructor(context, props = {}) {


### PR DESCRIPTION
The FEN object provides "start" and "empty" values that can be used to set the initial position when constructing Chessboard, so it should be easily accessible to the user.