### PR TITLE
fix in addElement of a svg

### DIFF
--- a/src/cm-chessboard/view/ChessboardView.js
+++ b/src/cm-chessboard/view/ChessboardView.js
@@ -509,7 +509,7 @@ export class Svg {
                 }
             }
         }
-        if (sibling !== undefined) {
+        if (sibling === undefined) {
           parent.appendChild(element)
         } else {
           parent.insertBefore(element, sibling)


### PR DESCRIPTION
I think there is an error in ChessboardView.j, when you call to the function "addElement" of a svg. If you pass the parameter "sibling" should be enter in insertBefore, not in appendChild.