### PR TITLE
SVGs with gradients don't work

### DIFF
--- a/src/view/ChessboardView.js
+++ b/src/view/ChessboardView.js
@@ -64,7 +64,7 @@ export class ChessboardView {
     cacheSpriteToDiv(wrapperId, url) {
         if (!document.getElementById(wrapperId)) {
             const wrapper = document.createElement("div")
-            wrapper.style.display = "none"
+            wrapper.style.transform = "scale(0)"
             wrapper.id = wrapperId
             document.body.appendChild(wrapper)
             const xhr = new XMLHttpRequest()


### PR DESCRIPTION
When using an SVG that contains gradients, these layers are not displayed.
It is due to the use of "display:none" which does not allow the reference to the gradient ID to be used.