### PR TITLE
small code cleanup, simplify constructor and nested statements

### DIFF
--- a/src/Chessboard.js
+++ b/src/Chessboard.js
@@ -122,7 +122,7 @@ export class Chessboard {
     async setOrientation(color, animated = false) {
         const position = this.state.position.clone()
         if (this.boardTurning) {
-            console.log("setOrientation is only once in queue allowed")
+            console.warn("setOrientation is only once in queue allowed")
             return
         }
         this.boardTurning = true

--- a/src/extensions/arrows/Arrows.js
+++ b/src/extensions/arrows/Arrows.js
@@ -78,10 +78,10 @@ export class Arrows extends Extension {
 
         const width = ((view.scalingX + view.scalingY) / 2) * 4
         let lineFill = Svg.addElement(arrowsGroup, "line")
-        lineFill.setAttribute('x1', x1)
-        lineFill.setAttribute('x2', x2)
-        lineFill.setAttribute('y1', y1)
-        lineFill.setAttribute('y2', y2)
+        lineFill.setAttribute('x1', x1.toString())
+        lineFill.setAttribute('x2', x2.toString())
+        lineFill.setAttribute('y1', y1.toString())
+        lineFill.setAttribute('y2', y2.toString())
         lineFill.setAttribute('class', 'arrow-line')
         lineFill.setAttribute("marker-end", "url(#" + id + ")")
         lineFill.setAttribute('stroke-width', width + "px")

--- a/src/model/ChessboardState.js
+++ b/src/model/ChessboardState.js
@@ -10,7 +10,6 @@ export class ChessboardState {
     constructor() {
         this.position = new Position()
         this.orientation = undefined
-        this.markers = []
         this.inputWhiteEnabled = false
         this.inputBlackEnabled = false
         this.inputEnabled = false

--- a/src/view/PositionAnimationsQueue.js
+++ b/src/view/PositionAnimationsQueue.js
@@ -145,7 +145,6 @@ export class PositionsAnimation {
 
     createAnimation(fromSquares, toSquares) {
         const changes = PositionsAnimation.seekChanges(fromSquares, toSquares)
-        // console.log("changes", changes)
         const animatedElements = []
         changes.forEach((change) => {
             const animatedItem = {
@@ -172,7 +171,6 @@ export class PositionsAnimation {
     }
 
     animationStep(time) {
-        // console.log("animationStep", time)
         if(!this.view || !this.view.chessboard.state) { // board was destroyed
             return
         }


### PR DESCRIPTION
- remove console.logs
- explicitly cast to string
- define methods outside of constructor, I dont see why this was required other than perhaps calling `view` instead of `this.view`
- use early returns for deeply nested if statements