### PR TITLE
fix promotion on mobile (Chrome) in the case that touchstart events get preventDefaulted

### DIFF
--- a/src/extensions/promotion-dialog/PromotionDialog.js
+++ b/src/extensions/promotion-dialog/PromotionDialog.js
@@ -179,7 +179,7 @@ export class PromotionDialog extends Extension {
         this.state.displayState = displayState
         if (displayState === DISPLAY_STATE.shown) {
             this.clickDelegate = Utils.delegate(this.chessboard.view.svg,
-                "mousedown",
+                "pointerdown",
                 "*",
                 this.promotionDialogOnClickPiece.bind(this))
             this.contextMenuListener = this.contextMenu.bind(this)


### PR DESCRIPTION
the mousedown event doesn't get emitted on mobile, making it impossible to promote, so use pointerdown instead