### PR TITLE
Fix autoMarkers property when defining the Markers extension.

### DIFF
--- a/examples/extensions/markers-extension.html
+++ b/examples/extensions/markers-extension.html
@@ -53,7 +53,7 @@
         position: "rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR",
         assetsUrl: "../../assets/",
         style: {pieces: {file: "pieces/staunty.svg"}},
-        extensions: [{class: Markers, autoMarkers: MARKER_TYPE.frame}]
+        extensions: [{class: Markers, props: {autoMarkers: MARKER_TYPE.frame}}]
     })
     board2.enableMoveInput(() => {
         return true


### PR DESCRIPTION
The 'autoMarkers' property in the example HTML file does nothing. This moves the 'autoMarkers' property into a 'props' object. When the 'autoMarker' property is in the 'props' object, changing it to (e.g.) 'MARKER_TYPE.circle' will modify the marker that is shown on the chessboard.