### PR TITLE
fix(extensions): add destroy handlers to prevent memory leaks

### DIFF
--- a/src/extensions/arrows/Arrows.js
+++ b/src/extensions/arrows/Arrows.js
@@ -25,6 +25,9 @@ export class Arrows extends Extension {
         this.registerExtensionPoint(EXTENSION_POINT.afterRedrawBoard, () => {
             this.onRedrawBoard()
         })
+        this.registerExtensionPoint(EXTENSION_POINT.destroy, () => {
+            this.onDestroy()
+        })
         this.props = {
             sprite: "extensions/arrows/arrows.svg",
             slice: "arrowDefault",
@@ -41,6 +44,16 @@ export class Arrows extends Extension {
         chessboard.removeArrows = this.removeArrows.bind(this)
         this.arrowGroup = Svg.addElement(chessboard.view.markersTopLayer, "g", {class: "arrows"})
         this.arrows = []
+    }
+
+    onDestroy() {
+        this.arrows.length = 0
+        if (this.arrowGroup && this.arrowGroup.parentNode) {
+            this.arrowGroup.parentNode.removeChild(this.arrowGroup)
+        }
+        delete this.chessboard.addArrow
+        delete this.chessboard.getArrows
+        delete this.chessboard.removeArrows
     }
 
     onRedrawBoard() {

--- a/src/extensions/auto-border-none/AutoBorderNone.js
+++ b/src/extensions/auto-border-none/AutoBorderNone.js
@@ -8,12 +8,16 @@ import {Extension, EXTENSION_POINT} from "../../model/Extension.js"
 export class AutoBorderNone extends Extension {
     constructor(chessboard, props = {}) {
         super(chessboard)
+        this.originalBorderType = chessboard.props.style.borderType
         this.props = {
             chessboardBorderType: chessboard.props.style.borderType,
             borderNoneBelow: 540 // pixels width of the board, where the border is set to none
         }
         Object.assign(this.props, props)
         this.registerExtensionPoint(EXTENSION_POINT.beforeRedrawBoard, this.extensionPointBeforeRedrawBoard.bind(this))
+        this.registerExtensionPoint(EXTENSION_POINT.destroy, () => {
+            this.chessboard.props.style.borderType = this.originalBorderType
+        })
     }
     extensionPointBeforeRedrawBoard() {
         let newBorderType

--- a/src/extensions/html-layer/HtmlLayer.js
+++ b/src/extensions/html-layer/HtmlLayer.js
@@ -3,14 +3,18 @@
  * Repository: https://github.com/shaack/cm-chessboard
  * License: MIT, see file 'LICENSE'
  */
-import {Extension} from "../../model/Extension.js"
+import {Extension, EXTENSION_POINT} from "../../model/Extension.js"
 
 export class HtmlLayer extends Extension {
     /** @constructor */
     constructor(chessboard) {
         super(chessboard)
+        this.layers = []
         chessboard.addHtmlLayer = this.addHtmlLayer.bind(this)
         chessboard.removeHtmlLayer = this.removeHtmlLayer.bind(this)
+        this.registerExtensionPoint(EXTENSION_POINT.destroy, () => {
+            this.onDestroy()
+        })
     }
     addHtmlLayer(html) {
         const layer = document.createElement("div")
@@ -23,9 +27,26 @@ export class HtmlLayer extends Extension {
         layer.style.bottom = "0"
         layer.style.right = "0"
         layer.innerHTML = html
+        this.layers.push(layer)
         return layer
     }
     removeHtmlLayer(layer) {
-        this.chessboard.context.removeChild(layer)
+        const index = this.layers.indexOf(layer)
+        if (index !== -1) {
+            this.layers.splice(index, 1)
+        }
+        if (layer && layer.parentNode === this.chessboard.context) {
+            this.chessboard.context.removeChild(layer)
+        }
+    }
+    onDestroy() {
+        for (const layer of this.layers) {
+            if (layer.parentNode) {
+                layer.parentNode.removeChild(layer)
+            }
+        }
+        this.layers.length = 0
+        delete this.chessboard.addHtmlLayer
+        delete this.chessboard.removeHtmlLayer
     }
 }

--- a/src/extensions/markers/Markers.js
+++ b/src/extensions/markers/Markers.js
@@ -29,6 +29,9 @@ export class Markers extends Extension {
         this.registerExtensionPoint(EXTENSION_POINT.afterRedrawBoard, () => {
             this.onRedrawBoard()
         })
+        this.registerExtensionPoint(EXTENSION_POINT.destroy, () => {
+            this.onDestroy()
+        })
         this.props = {
             autoMarkers: MARKER_TYPE.frame, // set to `null` to disable autoMarkers
             sprite: "extensions/markers/markers.svg" // the sprite file of the markers
@@ -51,6 +54,21 @@ export class Markers extends Extension {
                 this.drawAutoMarkers(event)
             })
         }
+    }
+
+    onDestroy() {
+        this.markers.length = 0
+        if (this.markerGroupDown && this.markerGroupDown.parentNode) {
+            this.markerGroupDown.parentNode.removeChild(this.markerGroupDown)
+        }
+        if (this.markerGroupUp && this.markerGroupUp.parentNode) {
+            this.markerGroupUp.parentNode.removeChild(this.markerGroupUp)
+        }
+        delete this.chessboard.addMarker
+        delete this.chessboard.getMarkers
+        delete this.chessboard.removeMarkers
+        delete this.chessboard.addLegalMovesMarkers
+        delete this.chessboard.removeLegalMovesMarkers
     }
 
     drawAutoMarkers(event) {

--- a/src/extensions/promotion-dialog/PromotionDialog.js
+++ b/src/extensions/promotion-dialog/PromotionDialog.js
@@ -91,14 +91,16 @@ export class PromotionDialog extends Extension {
         this.state.dialogParams.color = color
         this.state.callback = callback
         this.setDisplayState(DISPLAY_STATE.displayRequested)
-        setTimeout(() => {
-                this.chessboard.view.positionsAnimationTask.then(() => {
-                    this.setDisplayState(DISPLAY_STATE.shown)
-                    this.announce(this.t.choosePromotion + ": " +
-                        this.pieceOrder.map(p => this.t.pieces[p]).join(", "))
-                })
-            }
-        )
+        this.showTimeoutId = setTimeout(() => {
+            this.showTimeoutId = null
+            if (!this.chessboard.view) return // destroyed before timeout fired
+            this.chessboard.view.positionsAnimationTask.then(() => {
+                if (this.state.displayState !== DISPLAY_STATE.displayRequested) return
+                this.setDisplayState(DISPLAY_STATE.shown)
+                this.announce(this.t.choosePromotion + ": " +
+                    this.pieceOrder.map(p => this.t.pieces[p]).join(", "))
+            })
+        })
     }
 
     // public (chessboard.isPromotionDialogShown)
@@ -248,6 +250,7 @@ export class PromotionDialog extends Extension {
     }
 
     setDisplayState(displayState) {
+        const prevState = this.state.displayState
         this.state.displayState = displayState
         if (displayState === DISPLAY_STATE.shown) {
             this.clickDelegate = Utils.delegate(this.chessboard.view.svg,
@@ -259,19 +262,27 @@ export class PromotionDialog extends Extension {
             // Add keyboard listener
             document.addEventListener("keydown", this.handleKeyDown)
         } else if (displayState === DISPLAY_STATE.hidden) {
-            this.clickDelegate.remove()
-            this.chessboard.view.svg.removeEventListener("contextmenu", this.contextMenuListener)
+            if (this.clickDelegate) {
+                this.clickDelegate.remove()
+                this.clickDelegate = null
+            }
+            if (this.contextMenuListener && this.chessboard.view) {
+                this.chessboard.view.svg.removeEventListener("contextmenu", this.contextMenuListener)
+                this.contextMenuListener = null
+            }
             // Remove keyboard listener
             document.removeEventListener("keydown", this.handleKeyDown)
-            // Restore focus
-            if (this.previouslyFocusedElement && this.previouslyFocusedElement.focus) {
+            // Restore focus (only if the dialog was actually shown before)
+            if (prevState === DISPLAY_STATE.shown &&
+                this.previouslyFocusedElement && this.previouslyFocusedElement.focus) {
                 this.previouslyFocusedElement.focus()
             }
         }
         this.redrawDialog()
         // Focus first button after redraw when shown
         if (displayState === DISPLAY_STATE.shown) {
-            setTimeout(() => {
+            this.focusTimeoutId = setTimeout(() => {
+                this.focusTimeoutId = null
                 this.focusButton(0)
             }, 0)
         }
@@ -352,18 +363,45 @@ export class PromotionDialog extends Extension {
     }
 
     announce(message) {
+        if (!this.liveRegion) return
         this.liveRegion.textContent = ""
+        if (this.announceTimeoutId) {
+            clearTimeout(this.announceTimeoutId)
+        }
         // Small delay to ensure screen readers pick up the change
-        setTimeout(() => {
-            this.liveRegion.textContent = message
+        this.announceTimeoutId = setTimeout(() => {
+            this.announceTimeoutId = null
+            if (this.liveRegion) {
+                this.liveRegion.textContent = message
+            }
         }, 50)
     }
 
     destroy() {
+        // Close the dialog first so its listeners are removed
+        if (this.state.displayState === DISPLAY_STATE.shown) {
+            this.setDisplayState(DISPLAY_STATE.hidden)
+        }
+        // Cancel any pending timeouts so callbacks don't fire on a destroyed board
+        if (this.showTimeoutId) {
+            clearTimeout(this.showTimeoutId)
+            this.showTimeoutId = null
+        }
+        if (this.focusTimeoutId) {
+            clearTimeout(this.focusTimeoutId)
+            this.focusTimeoutId = null
+        }
+        if (this.announceTimeoutId) {
+            clearTimeout(this.announceTimeoutId)
+            this.announceTimeoutId = null
+        }
         document.removeEventListener("keydown", this.handleKeyDown)
         if (this.liveRegion && this.liveRegion.parentNode) {
             this.liveRegion.parentNode.removeChild(this.liveRegion)
+            this.liveRegion = null
         }
+        delete this.chessboard.showPromotionDialog
+        delete this.chessboard.isPromotionDialogShown
     }
 
 }


### PR DESCRIPTION
Hi @shaack — third focused PR following the split from #158 (alongside #159 and #160). This one is about memory leaks in extensions on board destroy. I wrote the regression tests first and confirmed all nine fail on current master before this commit, then confirmed all nine pass after it. I've ported the existing test/TestMarkers.js and test/TestChessboard.js scenarios to Playwright as well to verify nothing breaks.

## The problem

Five extensions currently leak resources when a \`Chessboard\` is destroyed. This matters for:
- Puzzle trainers and lesson apps that create and destroy boards repeatedly
- Analysis pages with multiple boards
- SPA navigation where a board is unmounted and remounted

For each extension, the specific leak symptoms are:

| Extension | Leak on destroy |
|---|---|
| **Markers** | \`markers\` array, two SVG \`<g>\` groups, and grafted methods (\`addMarker\`, \`getMarkers\`, \`removeMarkers\`, \`addLegalMovesMarkers\`, \`removeLegalMovesMarkers\`) on the chessboard instance |
| **Arrows** | \`arrows\` array, one SVG \`<g>\` group, and grafted methods (\`addArrow\`, \`getArrows\`, \`removeArrows\`) |
| **HtmlLayer** | Every layer added via \`addHtmlLayer\` stays in the DOM forever — the extension holds no reference so can't clean up |
| **AutoBorderNone** | Mutates \`chessboard.props.style.borderType\` at runtime but never restores it, polluting any shared props object reused for a second board |
| **PromotionDialog** | When destroyed while shown: leaks the pointerdown delegate and the contextmenu listener on \`view.svg\`. Also schedules three \`setTimeout\`s (show, focus, announce) that are never cancelled, so callbacks can fire on a destroyed board |

## The fixes

Every change is minimal and scoped to exactly the missing cleanup:

**Markers** — register a \`destroy\` extension point that runs \`onDestroy\`:
\`\`\`js
onDestroy() {
    this.markers.length = 0
    if (this.markerGroupDown && this.markerGroupDown.parentNode) {
        this.markerGroupDown.parentNode.removeChild(this.markerGroupDown)
    }
    if (this.markerGroupUp && this.markerGroupUp.parentNode) {
        this.markerGroupUp.parentNode.removeChild(this.markerGroupUp)
    }
    delete this.chessboard.addMarker
    delete this.chessboard.getMarkers
    delete this.chessboard.removeMarkers
    delete this.chessboard.addLegalMovesMarkers
    delete this.chessboard.removeLegalMovesMarkers
}
\`\`\`

**Arrows** — same pattern:
\`\`\`js
onDestroy() {
    this.arrows.length = 0
    if (this.arrowGroup && this.arrowGroup.parentNode) {
        this.arrowGroup.parentNode.removeChild(this.arrowGroup)
    }
    delete this.chessboard.addArrow
    delete this.chessboard.getArrows
    delete this.chessboard.removeArrows
}
\`\`\`

**HtmlLayer** — track added layers so they can be cleaned up:
\`\`\`js
constructor(chessboard) {
    super(chessboard)
    this.layers = []                             // ← new
    chessboard.addHtmlLayer = this.addHtmlLayer.bind(this)
    chessboard.removeHtmlLayer = this.removeHtmlLayer.bind(this)
    this.registerExtensionPoint(EXTENSION_POINT.destroy, () => this.onDestroy())
}
addHtmlLayer(html) {
    const layer = document.createElement("div")
    // ... existing styling ...
    this.layers.push(layer)                      // ← new
    return layer
}
removeHtmlLayer(layer) {
    const index = this.layers.indexOf(layer)    // ← keep this.layers in sync
    if (index !== -1) this.layers.splice(index, 1)
    if (layer && layer.parentNode === this.chessboard.context) {
        this.chessboard.context.removeChild(layer)
    }
}
onDestroy() {
    for (const layer of this.layers) {
        if (layer.parentNode) layer.parentNode.removeChild(layer)
    }
    this.layers.length = 0
    delete this.chessboard.addHtmlLayer
    delete this.chessboard.removeHtmlLayer
}
\`\`\`

**AutoBorderNone** — remember the original \`borderType\` and restore it on destroy:
\`\`\`js
constructor(chessboard, props = {}) {
    super(chessboard)
    this.originalBorderType = chessboard.props.style.borderType   // ← new
    // ... existing ...
    this.registerExtensionPoint(EXTENSION_POINT.destroy, () => {
        this.chessboard.props.style.borderType = this.originalBorderType
    })
}
\`\`\`

**PromotionDialog** — three related fixes:

1. \`setDisplayState(hidden)\` is now null-safe for the \`clickDelegate\` / \`contextMenuListener\` fields, and only restores focus if the dialog was actually shown before.
2. The three \`setTimeout\`s in \`showPromotionDialog\`, \`setDisplayState\`, and \`announce\` now store their ids in named fields so they can be cancelled.
3. \`destroy()\` now closes the dialog first (which removes the pointerdown delegate and contextmenu listener), clears all three timeout ids, and deletes the grafted \`showPromotionDialog\` / \`isPromotionDialogShown\` methods.

## Test methodology

I wrote the regression tests **first** — one per leak — designed to fail against clean upstream master. Only after confirming all nine fail did I apply the fixes, and then re-ran them to confirm all nine pass.

### Regression tests (fail on master, pass with this PR)

1. \`Markers: destroy deletes grafted methods from chessboard\`
2. \`Markers: destroy empties the markers array\`
3. \`Arrows: destroy deletes grafted methods from chessboard\`
4. \`Arrows: destroy empties the arrows array\`
5. \`HtmlLayer: destroy removes all added layers from the DOM\`
6. \`HtmlLayer: destroy deletes grafted methods\`
7. \`AutoBorderNone: destroy restores the original borderType\`
8. \`PromotionDialog: destroy while shown removes contextmenu listener\`
9. \`PromotionDialog: destroy deletes grafted methods\`

### Upstream compat tests (pass on both master and this PR)

I also ported your existing \`test/TestMarkers.js\` and \`test/TestChessboard.js\` scenarios to Playwright to confirm this PR doesn't break anything:

1. \`TestMarkers: set, get, remove markers (full scenario from upstream test)\`
2. \`TestChessboard: create and destroy without error\`
3. \`TestChessboard: set and get position\`
4. \`Arrows: full API works (add, get, filter, remove)\`
5. \`HtmlLayer: add and remove individual layer still works after PR C\`

All five pass. The \`removeHtmlLayer(layer)\` call in particular is important because I changed the internals (now keeps \`this.layers\` in sync), and this test verifies individual layer removal still works as before.

Both test files live in my fork (not committed here, since they depend on Playwright which isn't something you want in this project). Happy to share them in any form that would be useful — raw files, a gist, or inlined in the PR description.

## Not bundled

Per the direction you set on #158, this PR contains **only** the destroy handlers:

- No Playwright or new dev dependencies
- No breaking changes
- No deprecation removals
- No performance work (that's in #159 and #160)
- No changes to \`Chessboard.destroy\` itself, \`ChessboardView.destroy\`, or \`Utils.mergeObjects\` — those are on your list of bugs you'll handle yourself from #158

## Size

5 files, +111/-17. Each change is a local addition to one extension, no refactor.

\`\`\`
 src/extensions/arrows/Arrows.js                    | 13 +++++
 src/extensions/auto-border-none/AutoBorderNone.js  |  4 ++
 src/extensions/html-layer/HtmlLayer.js             | 25 +++++++-
 src/extensions/markers/Markers.js                  | 18 ++++++
 src/extensions/promotion-dialog/PromotionDialog.js | 68 +++++++++++++++++-----
 5 files changed, 111 insertions(+), 17 deletions(-)
\`\`\`