### PR TITLE
Allow control key as alternate to shift key when changing annotation colors

### DIFF
--- a/src/extensions/right-click-annotator/RightClickAnnotator.js
+++ b/src/extensions/right-click-annotator/RightClickAnnotator.js
@@ -108,7 +108,7 @@ export class RightClickAnnotator extends Extension {
             square,
             modifiers: {
                 alt: event.altKey,
-                shift: event.shiftKey
+                shift: event.shiftKey || event.ctrlKey
             }
         }
     }


### PR DESCRIPTION
Howdy, thanks for making this great library! Here's a tiny pr to get things working a bit better on Firefox (and possibly to help with some people's muscle memory).

On Firefox, the context menu `preventDefault()` doesn't work if shift is being held. I don't know if it's intentional or a bug or whatever, but regardless, it means some colors can't be obtained with the RightClickAnnotator on Firefox. The red and yellow colors require shift to be held and something about the context menu prevents the annotations from being created.

This PR does what Lichess does to solve the issue - just allow the control key to be used as well :) Shift and control are now identical for creating annotations with different colors - control will create red annotations, and control + alt will create yellow annotations. This enables red and yellow arrows/circles to be created on Firefox without issue.

(Potentially of note: on Lichess+Firefox, the shift key causes a context menu to appear but the annotations still gets created just fine. The context menu gets in the way but it still seems to work, maybe cm-chessboard should do the same? Very minor)

Thanks again for making this library! I've been using it in some small projects and I really like it so far. Keep it up :)