### PR TITLE
Cancel an in-progress input move if the piece being held changes

### DIFF
--- a/src/Chessboard.js
+++ b/src/Chessboard.js
@@ -93,6 +93,7 @@ export class Chessboard {
         const positionTo = new Position(fen)
         if (positionFrom.getFen() !== positionTo.getFen()) {
             this.state.position.setFen(fen)
+            this.view.visualMoveInput.positionChanged()
             this.state.invokeExtensionPoints(EXTENSION_POINT.positionChanged)
         }
         return this.positionAnimationsQueue.enqueuePositionChange(positionFrom, this.state.position.clone(), animated)

--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -23,7 +23,8 @@ export const MOVE_CANCELED_REASON = {
     secondaryClick: "secondaryClick", // right click while moving
     movedOutOfBoard: "movedOutOfBoard",
     draggedBack: "draggedBack", // dragged to the start square
-    clickedAnotherPiece: "clickedAnotherPiece" // of the same color
+    clickedAnotherPiece: "clickedAnotherPiece", // of the same color
+    movedPieceChanged: "movedPieceChanged" // most likely got captured
 }
 
 const DRAG_THRESHOLD = 4
@@ -36,6 +37,7 @@ export class VisualMoveInput {
         this.moveInputState = null
         this.fromSquare = null
         this.toSquare = null
+        this.movedPiece = null
 
         this.setMoveInputState(MOVE_INPUT_STATE.waitForInputStart)
     }
@@ -406,6 +408,16 @@ export class VisualMoveInput {
         this.view.redrawPieces()
         this.setMoveInputState(MOVE_INPUT_STATE.reset)
         this.moveInputCanceledCallback(this.fromSquare, null, MOVE_CANCELED_REASON.secondaryClick)
+    }
+
+    positionChanged() {
+        if (this.fromSquare) {
+            const pieceName = this.chessboard.getPiece(this.fromSquare)
+            if (pieceName != this.movedPiece) {
+                this.setMoveInputState(MOVE_INPUT_STATE.reset)
+                this.moveInputCanceledCallback(this.fromSquare, null, MOVE_CANCELED_REASON.movedPieceChanged)
+            }
+        }
     }
 
     isDragging() {


### PR DESCRIPTION
Previously, if you click a piece to select it or start dragging it, and that piece gets changed when the position changes (i.e. the piece you're holding gets captured), the chessboard ends up in a weird state where an invalid piece is still being held. If it's being dragged, that will make the new piece turn invisible (since dragged pieces become invisible in their original spot until the drag finishes) and is otherwise kinda glitchy.

Since there's already a well defined callback for a move getting cancelled, this seems like a good place to use it. Now, when the position changes and there's a piece being held, it checks if the piece on that square is different than what it was and if so, it will cancel the move.