### PR TITLE
In RightClickAnnotator, only remove arrows/markers created by itself

### DIFF
--- a/src/extensions/right-click-annotator/RightClickAnnotator.js
+++ b/src/extensions/right-click-annotator/RightClickAnnotator.js
@@ -77,8 +77,14 @@ export class RightClickAnnotator extends Extension {
     }
 
     setAnnotations(annotations) {
-        this.chessboard.removeArrows()
-        this.chessboard.removeMarkers()
+        this.chessboard.removeArrows(ARROW_TYPE.info)
+        this.chessboard.removeArrows(ARROW_TYPE.danger)
+        this.chessboard.removeArrows(ARROW_TYPE.warning)
+        this.chessboard.removeArrows(ARROW_TYPE.success)
+        this.chessboard.removeMarkers(MARKER_TYPE.info)
+        this.chessboard.removeMarkers(MARKER_TYPE.danger)
+        this.chessboard.removeMarkers(MARKER_TYPE.warning)
+        this.chessboard.removeMarkers(MARKER_TYPE.success)
         if (annotations.arrows) {
             for (const arrow of annotations.arrows) {
                 this.chessboard.addArrow(arrow.type, arrow.from, arrow.to)
@@ -131,7 +137,10 @@ export class RightClickAnnotator extends Extension {
             if (existing && existing.length > 0) {
                 this.chessboard.removeArrows(arrowType, start.square, endSquare)
             } else {
-                this.chessboard.removeArrows(undefined, start.square, endSquare)
+                this.chessboard.removeArrows(ARROW_TYPE.info, start.square, endSquare)
+                this.chessboard.removeArrows(ARROW_TYPE.danger, start.square, endSquare)
+                this.chessboard.removeArrows(ARROW_TYPE.warning, start.square, endSquare)
+                this.chessboard.removeArrows(ARROW_TYPE.success, start.square, endSquare)
                 this.chessboard.addArrow(arrowType, start.square, endSquare)
             }
         } else if (start.square) {
@@ -140,7 +149,10 @@ export class RightClickAnnotator extends Extension {
             if (existingMarkers && existingMarkers.length > 0) {
                 this.chessboard.removeMarkers(circleType, start.square)
             } else {
-                this.chessboard.removeMarkers(undefined, start.square)
+                this.chessboard.removeMarkers(MARKER_TYPE.info, start.square)
+                this.chessboard.removeMarkers(MARKER_TYPE.danger, start.square)
+                this.chessboard.removeMarkers(MARKER_TYPE.warning, start.square)
+                this.chessboard.removeMarkers(MARKER_TYPE.success, start.square)
                 this.chessboard.addMarker(circleType, start.square)
             }
         }


### PR DESCRIPTION
Another tiny PR :)

The right click annotator will remove any marker or arrow on the chessboard when clicking, not just the ones created by the right click annotator. I use markers to highlight the last legal move and to show if the king is in check, and without this change, if you right click on those squares it will remove those markers.

This PR narrows the `removeArrows` and `removeMarkers` calls to remove only the arrows that are created by the right click annotator, and not any other markers/arrows that might exist on the board from other sources.