### PR TITLE
Fix Utils.delegate firing handler for each ancestor

### DIFF
--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -8,12 +8,9 @@ export class Utils {
 
     static delegate(element, eventName, selector, handler) {
         const eventListener = function (event) {
-            let target = event.target
-            while (target && target !== this) {
-                if (target.matches(selector)) {
-                    handler.call(target, event)
-                }
-                target = target.parentNode
+            const match = event.target.closest(selector);
+            if (match && this.contains(match)) {
+                handler.call(match, event);
             }
         }
         element.addEventListener(eventName, eventListener)


### PR DESCRIPTION
Hello! I've recently started using this awesome package and think I've discovered a subtle bug.

`Utils.delegate` walks every ancestor of `event.target` up to the listener root and calls the handler for every ancestor. I assume this is unintentional and it's actually causing a hidden error. The current behaviour is invisible for most selectors as there's usually only one match in the chain, but it pops up as a duplicate invocation whenever the selector has multiple matches.

It only became apparent when trying to promote a piece. The `PromotionDialog` extension registers its click handler with the selector `"*"`, so a single pointerdown on a promotion piece walks the chain and calls `promotionDialogOnClickPiece` for each ancestor. Each call resolves to the same `data-piece` via `.closest()` and calls `selectPiece` again, firing the promotion callback twice.

## Reproduction

The examples use your package, [chess.mjs](https://www.npmjs.com/package/chess.mjs), where invalid moves return `null`. This is completely fine, but has masked this unwanted behaviour in this case.

Swap to [chess.js](https://github.com/jhlywa/chess.js), where invalid moves throw and you should see some duplicate calls.

In `examples/validation-and-promotion-dialog.html`:

```diff
- import { Chess } from "https://cdn.jsdelivr.net/npm/chess.mjs@1/src/chess.mjs/Chess.js"
+ import { Chess } from "https://esm.sh/chess.js"
```

Promote any pawn:

```Uncaught Error: Invalid move: {"from":"g7","to":"h8","promotion":"q"}```

## Fix

Stop after the first match in `src/lib/Utils.js`:


```diff
 const eventListener = function (event) {
-    let target = event.target
-    while (target && target !== this) {
-        if (target.matches(selector)) {
-            handler.call(target, event)
-        }
-        target = target.parentNode
-    }
+    const match = event.target.closest(selector)
+    if (match && this.contains(match)) {
+        handler.call(match, event)
+    }
 }
```