### PR TITLE
Reset move input state on touchcancel

### DIFF
--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -23,7 +23,8 @@ export const MOVE_CANCELED_REASON = {
     secondaryClick: "secondaryClick", // right click while moving
     movedOutOfBoard: "movedOutOfBoard",
     draggedBack: "draggedBack", // dragged to the start square
-    clickedAnotherPiece: "clickedAnotherPiece" // of the same color
+    clickedAnotherPiece: "clickedAnotherPiece", // of the same color
+    touchCanceled: "touchCanceled"
 }
 
 const DRAG_THRESHOLD = 4
@@ -90,6 +91,10 @@ export class VisualMoveInput {
                     removeEventListener(this.pointerUpListener.type, this.pointerUpListener)
                     this.pointerUpListener = null
                 }
+                if (this.pointerCancelListener) {
+                    removeEventListener(this.pointerCancelListener.type, this.pointerCancelListener)
+                    this.pointerCancelListener = null
+                }
                 this.fromSquare = params.square
                 this.toSquare = null
                 this.movedPiece = params.piece
@@ -109,6 +114,9 @@ export class VisualMoveInput {
                         this.pointerUpListener = this.onPointerUp.bind(this)
                         this.pointerUpListener.type = "touchend"
                         addEventListener("touchend", this.pointerUpListener)
+                        this.pointerCancelListener = this.onPointerCancel.bind(this)
+                        this.pointerCancelListener.type = "touchcancel"
+                        addEventListener("touchcancel", this.pointerCancelListener)
                     } else {
                         throw Error("4b74af")
                     }
@@ -194,6 +202,10 @@ export class VisualMoveInput {
                 if (this.pointerUpListener) {
                     removeEventListener(this.pointerUpListener.type, this.pointerUpListener)
                     this.pointerUpListener = null
+                }
+                if (this.pointerCancelListener) {
+                    removeEventListener(this.pointerCancelListener.type, this.pointerCancelListener)
+                    this.pointerCancelListener = null
                 }
                 if (this.contextMenuListener) {
                     removeEventListener("contextmenu", this.contextMenuListener)
@@ -399,6 +411,13 @@ export class VisualMoveInput {
             this.view.redrawPieces()
             this.setMoveInputState(MOVE_INPUT_STATE.reset)
         }
+    }
+
+    onPointerCancel() {
+        this.view.redrawPieces()
+        const moveStartSquare = this.fromSquare
+        this.setMoveInputState(MOVE_INPUT_STATE.reset)
+        this.moveInputCanceledCallback(moveStartSquare, null, MOVE_CANCELED_REASON.touchCanceled)
     }
 
     onContextMenu(e) { // while moving

--- a/test/TestVisualMoveInput.js
+++ b/test/TestVisualMoveInput.js
@@ -1,0 +1,40 @@
+/**
+ * Author and copyright: Stefan Haack (https://shaack.com)
+ * Repository: https://github.com/shaack/cm-chessboard
+ * License: MIT, see file 'LICENSE'
+ */
+
+import {describe, it, assert} from "../node_modules/teevi/src/teevi.js"
+import {Chessboard} from "../src/Chessboard.js"
+import {FEN} from "../src/model/Position.js"
+
+const STATE_WAIT_FOR_INPUT_START = "waitForInputStart"
+const STATE_PIECE_CLICKED_THRESHOLD = "pieceClickedThreshold"
+
+describe("TestVisualMoveInput", () => {
+
+    it("should reset move input state on touchcancel", async () => {
+        const chessboard = new Chessboard(document.getElementById("TestBoard"), {
+            assetsUrl: "../assets/",
+            position: FEN.start
+        })
+        chessboard.enableMoveInput(() => true)
+        const visualMoveInput = chessboard.view.visualMoveInput
+
+        visualMoveInput.onPointerDown({
+            type: "touchstart",
+            target: {getAttribute: (name) => (name === "data-square" ? "e2" : null)},
+            touches: [{clientX: 100, clientY: 100}],
+            preventDefault: () => {}
+        })
+        assert.equal(visualMoveInput.moveInputState, STATE_PIECE_CLICKED_THRESHOLD)
+
+        window.dispatchEvent(new Event("touchcancel"))
+
+        assert.equal(visualMoveInput.moveInputState, STATE_WAIT_FOR_INPUT_START)
+
+        await new Promise((resolve) => setTimeout(resolve))
+        chessboard.destroy()
+    })
+
+})

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,7 @@
     import "./TestPiecesAnimation.js"
     import "./TestMarkers.js"
     import "./TestPosition.js"
+    import "./TestVisualMoveInput.js"
     teevi.run()
 </script>
 </body>


### PR DESCRIPTION
Closes #168.

## Problem

On touch devices the board can permanently stop responding to taps: you can no longer pick up a piece to move, and it only recovers by reloading the page or tapping outside the board.

On `touchstart`, `setMoveInputState(pieceClickedThreshold)` registers global `touchmove` and `touchend` listeners but no `touchcancel` listener. The only exits from `pieceClickedThreshold` are `touchmove` (→ `dragTo`) and `touchend` (→ `clickTo` / `reset`). When the browser cancels the active touch (scroll takeover, second finger, system edge-swipe, long-press context menu, incoming call, ...) it fires `touchcancel` instead of `touchend`, so neither exit runs. The machine is left stuck in `pieceClickedThreshold` with the global listeners leaked, and `onPointerDown` refuses to start a new move because it requires `waitForInputStart` — every following tap is ignored.

## Fix

Register a `touchcancel` listener alongside `touchmove`/`touchend` in the `touchstart` branch, and remove it in the same teardown paths as the other pointer listeners. On `touchcancel`, `onPointerCancel` redraws the pieces and resets the state machine — mirroring the existing off-board pointer-up cancel — and reports a new `MOVE_CANCELED_REASON.touchCanceled`.

## Test

`test/TestVisualMoveInput.js` drives `touchstart` → `touchcancel` and asserts the state machine returns to `waitForInputStart`. It fails on the current code and passes with this change. The full Teevi suite (`test/index.html`) stays green.
