### PR TITLE
Cancel move input when a piece is dragged back

### DIFF
--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -372,14 +372,10 @@ export class VisualMoveInput {
             if (square) {
                 if (this.moveInputState === MOVE_INPUT_STATE.dragTo || this.moveInputState === MOVE_INPUT_STATE.clickDragTo) {
                     if (this.fromSquare === square) {
-                        if (this.moveInputState === MOVE_INPUT_STATE.clickDragTo) {
-                            this.chessboard.state.position.setPiece(this.fromSquare, this.movedPiece)
-                            this.view.setPieceVisibility(this.fromSquare)
-                            this.moveInputCanceledCallback(square, null, MOVE_CANCELED_REASON.draggedBack)
-                            this.setMoveInputState(MOVE_INPUT_STATE.reset)
-                        } else {
-                            this.setMoveInputState(MOVE_INPUT_STATE.clickTo, {square: square})
-                        }
+                        this.chessboard.state.position.setPiece(this.fromSquare, this.movedPiece)
+                        this.view.setPieceVisibility(this.fromSquare)
+                        this.moveInputCanceledCallback(square, null, MOVE_CANCELED_REASON.draggedBack)
+                        this.setMoveInputState(MOVE_INPUT_STATE.reset)
                     } else {
                         this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square})
                     }


### PR DESCRIPTION
## Summary
- cancel move input when a dragged piece is released on its origin square
- use the existing `draggedBack` cancellation path for both drag states
- prevent a stale click-to-move selection from affecting the next piece selection

Fixes #170.

## Test plan
- [x] `node --check src/view/VisualMoveInput.js`
- [ ] Browser test: drag a piece away and back, then select another piece; no pending move remains
