### PR TITLE
Fix contextmenu listener leak in VisualMoveInput, suppress native menu on board

### DIFF
--- a/src/view/ChessboardView.js
+++ b/src/view/ChessboardView.js
@@ -68,6 +68,10 @@ export class ChessboardView {
         this.pointerDownListener = this.pointerDownHandler.bind(this)
         this.container.addEventListener("mousedown", this.pointerDownListener)
         this.container.addEventListener("touchstart", this.pointerDownListener, {passive: false})
+        // Suppress the native context menu on the whole board
+        // VisualMoveInput triggers a move cancel with a transient listener on right click
+        this.contextMenuListener = (e) => e.preventDefault()
+        this.container.addEventListener("contextmenu", this.contextMenuListener)
         this.createSvgAndGroups()
         this.handleResize()
     }
@@ -91,8 +95,9 @@ export class ChessboardView {
         if (this.resizeListener) {
             window.removeEventListener("resize", this.resizeListener)
         }
-        this.chessboard.context.removeEventListener("mousedown", this.pointerDownListener)
-        this.chessboard.context.removeEventListener("touchstart", this.pointerDownListener)
+        this.container.removeEventListener("mousedown", this.pointerDownListener)
+        this.container.removeEventListener("touchstart", this.pointerDownListener)
+        this.container.removeEventListener("contextmenu", this.contextMenuListener)
         Svg.removeElement(this.svg)
         this.container.remove()
     }

--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -196,7 +196,7 @@ export class VisualMoveInput {
                     this.pointerUpListener = null
                 }
                 if (this.contextMenuListener) {
-                    removeEventListener("contextmenu", this.contextMenuListener)
+                    this.chessboard.view.svg.removeEventListener("contextmenu", this.contextMenuListener)
                     this.contextMenuListener = null
                 }
                 this.setMoveInputState(MOVE_INPUT_STATE.waitForInputStart)


### PR DESCRIPTION
Fixes #172

## What

- `VisualMoveInput`'s `reset` transition removed the contextmenu listener via a bare `removeEventListener("contextmenu", ...)`, which targets `window`. It was added to `this.chessboard.view.svg`, so removal was always a no-op — every pick-up/cancel cycle left one more live listener on the SVG, and a later right-click fires `moveInputCanceled` once per prior gesture instead of once. Retargeted the removal at `this.chessboard.view.svg` to match where it's added.
- `ChessboardView.destroy()` had the same class of mismatch: `mousedown`/`touchstart` were added to `this.container` but removed from `this.chessboard.context` (the consumer-supplied host element — a different node). Retargeted at `this.container` for consistency, and cleaned up the new contextmenu listener the same way.
- Added a permanent `contextmenu` → `preventDefault()` on `this.container`, so the native context menu is suppressed on the whole board at all times, not only while a piece is actively being moved (which is all the existing `VisualMoveInput` listener covers).

## Testing

- Ran the existing Teevi test suite (`test/index.html`) against the patched source — all passing.
- Manually verified against `examples/enable-input.html` served locally: repeated pick-up + right-click no longer produces duplicate `moveInputCanceled` logs, and right-clicking the board with no piece in hand no longer shows the native context menu.
- Markers on right click still work with the board `contextmenu` listener that disables all right clicks inside board, as can be tested in the test suite.