### PR TITLE
Fix validateMoveInputCallback being invoked twice for one click move

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,14 @@ The event has the following **`event.type`**:
   Return `true` or `false` to validate the start square. `false` cancels the move.
 - **`INPUT_EVENT_TYPE.validateMoveInput`**: To validate the users move input. `event.squareFrom` and `event.squareTo`
   contain the coordinates. Return `true` or `false` to validate the move. `false` cancels the move.
-  `event.probe` is `true` when the target square still holds one of the mover's own pieces (e.g. clicking another own
-  piece, or a chess960 castling target). A falsy result then means "re-select that piece" rather than an illegal move,
-  so you can suppress illegal-move feedback when `event.probe` is set.
+  The validator runs once at most per sequence of actions that describe a move (e.g. click starting piece, click destination),
+  so side effects like updating game position state or triggering sounds can run here.
+  One special case is moving a piece to a square occupied by another friendly piece. This kind of move can be useful
+  when you want to allow chess960 castling style (moving the king into the rook position) or when you want to allow
+  recapture premoves. `event.probe` is `true` when the target square still holds one of the mover's own pieces.
+  Here, a falsy result by the validator means "re-select that piece" rather than an illegal move,
+  so you can suppress illegal-move feedback when `event.probe` is set. A truthy result under `event.probe` still commits
+  the move (e.g. castling by clicking the rook).
 - **`INPUT_EVENT_TYPE.moveInputCanceled`**: The user canceled the move with clicking again on the start square, clicking
   outside the board or right click.
 - **`INPUT_EVENT_TYPE.moveInputFinished`**: Fired after the move was made, also when canceled.

--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -171,7 +171,9 @@ export class VisualMoveInput {
                     throw new Error("moveInputState")
                 }
                 this.toSquare = params.square
-                if (this.toSquare && this.validateMoveInputCallback(this.fromSquare, this.toSquare)) {
+                const validated = params.validated !== undefined ?
+                    params.validated : this.validateMoveInputCallback(this.fromSquare, this.toSquare)
+                if (this.toSquare && validated) {
                     this.chessboard.movePiece(this.fromSquare, this.toSquare, prevState === MOVE_INPUT_STATE.clickTo).then(() => {
                         if (prevState === MOVE_INPUT_STATE.clickTo) {
                             this.view.setPieceVisibility(this.toSquare, true)
@@ -314,6 +316,8 @@ export class VisualMoveInput {
                             } else {
                                 this.setMoveInputState(MOVE_INPUT_STATE.reset)
                             }
+                        } else {
+                            this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square, validated: result})
                         }
                     } else {
                         this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square})

--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -171,7 +171,8 @@ export class VisualMoveInput {
                     throw new Error("moveInputState")
                 }
                 this.toSquare = params.square
-                const validated = params.validated !== undefined ?
+                // if the move was already validated, don't trigger the validator again so possible user side effects run once at most
+                const validated = params.validated !== undefined ? 
                     params.validated : this.validateMoveInputCallback(this.fromSquare, this.toSquare)
                 if (this.toSquare && validated) {
                     this.chessboard.movePiece(this.fromSquare, this.toSquare, prevState === MOVE_INPUT_STATE.clickTo).then(() => {
@@ -300,11 +301,11 @@ export class VisualMoveInput {
                     const startPieceName = this.chessboard.getPiece(this.fromSquare)
                     const startPieceColor = startPieceName ? startPieceName.substring(0, 1) : null
                     if (color && startPieceColor === pieceColor) {
-                        // added to allow chess960 castling. This is only a probe:
-                        // a falsy result means the user re-selected another own
-                        // piece, not that an illegal move was attempted.
+                        // added to allow moves into own pieces, useful for chess960 castle style or recapture premoves
+                        // result holds false if the user legality checker deemed the move into another own piece as illegal
+                        // in that case, we start a new move by selecting the target piece
                         const result = this.validateMoveInputCallback(this.fromSquare, square, true)
-                        if(!result) {
+                        if (!result) {
                             this.moveInputCanceledCallback(this.fromSquare, square, MOVE_CANCELED_REASON.clickedAnotherPiece)
                             if (this.moveInputStartedCallback(square)) {
                                 this.setMoveInputState(MOVE_INPUT_STATE.pieceClickedThreshold, {
@@ -317,7 +318,9 @@ export class VisualMoveInput {
                                 this.setMoveInputState(MOVE_INPUT_STATE.reset)
                             }
                         } else {
-                            this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square, validated: result})
+                            // if the user deemed the move into own piece legal, execute it
+                            // but prevent validating the move again with the validated flag
+                            this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square, validated: true})
                         }
                     } else {
                         this.setMoveInputState(MOVE_INPUT_STATE.moveDone, {square: square})

--- a/test/TestVisualMoveInput.js
+++ b/test/TestVisualMoveInput.js
@@ -74,4 +74,45 @@ describe("TestVisualMoveInput", () => {
         chessboard.destroy()
     })
 
+    // Regression for https://github.com/shaack/cm-chessboard/pull/174
+    it("should validate once and finish the move when moving into own piece is marked as valid", async () => {
+        const chessboard = new Chessboard(document.getElementById("TestBoard"), {
+            assetsUrl: "../assets/",
+            position: FEN.start
+        })
+        let validateCallCount = 0
+        let moveInputFinishedCount = 0
+        chessboard.enableMoveInput((event) => {
+            if (event.type === INPUT_EVENT_TYPE.validateMoveInput) {
+                validateCallCount++
+                return true // accept the castling-by-clicking-the-rook move
+            } else if (event.type === INPUT_EVENT_TYPE.moveInputFinished) {
+                moveInputFinishedCount++
+            }
+            return true
+        }, COLOR.white)
+        const visualMoveInput = chessboard.view.visualMoveInput
+
+        // simulate an existing click-to-move selection of the white king on e1
+        visualMoveInput.moveInputStartedCallback("e1")
+        visualMoveInput.moveInputState = STATE_CLICK_TO
+        visualMoveInput.fromSquare = "e1"
+
+        // castle by clicking the rook on h1 -> same-color-click (probe) branch
+        visualMoveInput.onPointerDown({
+            type: "touchstart",
+            target: {getAttribute: (name) => (name === "data-square" ? "h1" : null)},
+            touches: [{clientX: 100, clientY: 100}],
+            preventDefault: () => {}
+        })
+
+        assert.equal(validateCallCount, 1)
+
+        await new Promise((resolve) => setTimeout(resolve))
+        // the move must complete (not get stuck in `clickTo`), firing moveInputFinished exactly once
+        assert.equal(moveInputFinishedCount, 1)
+
+        chessboard.destroy()
+    })
+
 })


### PR DESCRIPTION
## Summary
In `VisualMoveInput`'s same-color-click branch of `onPointerDown` (added for chess960 castling), a truthy `validateMoveInputCallback` result did nothing: the input state stayed stuck in `clickTo`, so the piece was never placed and `moveInputFinished` never fired. This affects any move that legally targets a square still occupied by one of the mover's own pieces — e.g. a premove betting the opponent vacates that square before it plays out, or castling by clicking the rook.

Routing that case through `moveDone` fixes the stuck state, but `moveDone` unconditionally re-runs `validateMoveInputCallback`, so the callback would fire twice for a single move. That's a real problem for any consumer whose callback has side effects (applying the move, queuing a premove, etc).

## Fix
`moveDone` now accepts an optional `validated` param — a caller that already has the result (like the same-color-click branch) passes it through instead of triggering a second validation call. Every other call site of `moveDone` is unaffected, since `validated` defaults to re-validating when not supplied.

## Test plan
- [x] Click-to-move a piece onto a square still occupied by one of the player's own pieces where the target callback accepts the move (premove scenario) — move now completes visually instead of leaving the input stuck.
- [x] Click a different own-color piece to reselect (validateMoveInputCallback returns false) — still cancels/reselects correctly, no regression.
- [x] `node --check` on the modified file.