### PR TITLE
feat(view): let validateMoveInput opt a click move out of its completion animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ The event has the following **`event.type`**:
   recapture premoves. Return `true` to commit it (e.g. castling by clicking the rook). When you return `false` here the
   clicked own piece simply becomes the new selection, so if you show illegal-move feedback, skip it when `event.squareTo`
   still holds one of the mover's own pieces.
+  A move made by click always plays its own move animation. Set `event.animate = false` before returning to skip it for this move only
+  (e.g. a premove made by click) — this is read once, right after validation, so there is nothing to reset afterward.
 - **`INPUT_EVENT_TYPE.moveInputCanceled`**: The user canceled the move with clicking again on the start square, clicking
   outside the board or right click.
 - **`INPUT_EVENT_TYPE.moveInputFinished`**: Fired after the move was made, also when canceled.

--- a/src/view/ChessboardView.js
+++ b/src/view/ChessboardView.js
@@ -421,6 +421,9 @@ export class ChessboardView {
         if (this.chessboard.state.moveInputCallback) {
             data.moveInputCallbackResult = this.chessboard.state.moveInputCallback(data)
         }
+        // A validator can set `event.animate = false` to skip this move's own completion animation 
+        // (e.g. a premove made by click, which would otherwise always animate)
+        this.chessboard.state.moveInputAnimate = data.animate
         this.chessboard.state.invokeExtensionPoints(EXTENSION_POINT.moveInput, data)
         return data.moveInputCallbackResult
     }

--- a/src/view/VisualMoveInput.js
+++ b/src/view/VisualMoveInput.js
@@ -178,7 +178,10 @@ export class VisualMoveInput {
                 const validated = params.validated !== undefined ? 
                     params.validated : this.validateMoveInputCallback(this.fromSquare, this.toSquare)
                 if (this.toSquare && validated) {
-                    this.chessboard.movePiece(this.fromSquare, this.toSquare, prevState === MOVE_INPUT_STATE.clickTo).then(() => {
+                    // A click move always completes with its own animation, unless the
+                    // validator opted out via `event.animate = false` (see ChessboardView).
+                    const animate = prevState === MOVE_INPUT_STATE.clickTo && this.chessboard.state.moveInputAnimate !== false
+                    this.chessboard.movePiece(this.fromSquare, this.toSquare, animate).then(() => {
                         if (prevState === MOVE_INPUT_STATE.clickTo) {
                             this.view.setPieceVisibility(this.toSquare, true)
                         }

--- a/test/TestVisualMoveInput.js
+++ b/test/TestVisualMoveInput.js
@@ -124,6 +124,58 @@ describe("TestVisualMoveInput", () => {
         board.destroy()
     })
 
+    // A click move always completes with its own animation (see the test above),
+    // which is unwanted for premoves made by click. `event.animate = false` in the
+    // validator lets a consumer opt out per-move instead of having to toggle
+    // `chessboard.props.style.animationDuration` around the move.
+    it("should skip a click move's own animation when the validator sets event.animate = false", async () => {
+        const board = newBoard()
+        let capturedAnimated = null
+        const originalMovePiece = board.movePiece.bind(board)
+        board.movePiece = (from, to, animated) => {
+            capturedAnimated = animated
+            return originalMovePiece(from, to, animated)
+        }
+        board.enableMoveInput((e) => {
+            if (e.type === INPUT_EVENT_TYPE.validateMoveInput) {
+                e.animate = false
+                return true
+            }
+            return true
+        }, COLOR.white)
+        const vmi = board.view.visualMoveInput
+
+        vmi.onPointerDown(mouseDown("e2"))
+        vmi.onPointerUp(mouseUp("e2"))
+        vmi.onPointerDown(mouseDown("e4"))
+        await tick()
+
+        assert.equal(capturedAnimated, false)
+        assert.equal(board.getPiece("e4"), "wp")
+        board.destroy()
+    })
+
+    it("should still animate a click move by default (event.animate untouched)", async () => {
+        const board = newBoard()
+        let capturedAnimated = null
+        const originalMovePiece = board.movePiece.bind(board)
+        board.movePiece = (from, to, animated) => {
+            capturedAnimated = animated
+            return originalMovePiece(from, to, animated)
+        }
+        board.enableMoveInput(() => true, COLOR.white)
+        const vmi = board.view.visualMoveInput
+
+        vmi.onPointerDown(mouseDown("e2"))
+        vmi.onPointerUp(mouseUp("e2"))
+        vmi.onPointerDown(mouseDown("e4"))
+        await tick()
+
+        assert.equal(capturedAnimated, true)
+        assert.equal(board.getPiece("e4"), "wp");
+        board.destroy()
+    })
+
     it("should complete a drag move to a new square", async () => {
         const board = newBoard()
         board.enableMoveInput(() => true, COLOR.white)


### PR DESCRIPTION
Fixes #175

## Summary
- A click-to-click move always completes with `chessboard.movePiece(from, to, true)`, ignoring the `animated` flag a consumer passes elsewhere — see #175 for the full writeup (a click premove slides while the equivalent drag premove snaps).
- `validateMoveInput` handlers can now set `event.animate = false` to opt that one move out of its own completion animation. It's read once, right after validation, so there's nothing to reset afterward — no need to mutate `props.style.animationDuration` and restore it on a later microtask.
- Default behavior (no `event.animate` set) is unchanged: a click move still animates.

## Test plan
- [x] Added a regression test asserting a click move honors `event.animate = false` (the `animated` param passed to `movePiece` is `false`).
- [x] Added a regression test asserting a click move still animates by default when `event.animate` is untouched.
- [x] `npm run test:headless` — all 46 tests pass.